### PR TITLE
PES-665: Readme.txt revision and packetery.php version numbers control

### DIFF
--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -7,7 +7,7 @@
  * @wordpress-plugin
  *
  * Plugin Name: Packeta
- * Description: With the help of our official plugin, You can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in Your e-shop. You can also submit all your orders to Packeta with just one click.
+ * Description: This is the official plugin, with which you can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. Furthermore, you can also submit all your orders to Packeta with just one click.
  * Version: 1.2.0
  * Author: Zásilkovna s.r.o.
  * Author URI: https://www.zasilkovna.cz/

--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -16,7 +16,7 @@
  * Requires at least: 5.3
  * Requires PHP: 7.2
  *
- * WP Tested up to: 5.9.2
+ * Tested up to: 5.9.2
  * WC requires at least: 4.5
  * WC tested up to: 6.3.1
  *

--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -7,7 +7,7 @@
  * @wordpress-plugin
  *
  * Plugin Name: Packeta
- * Description: This is the official plugin, with which you can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. Furthermore, you can also submit all your orders to Packeta with just one click.
+ * Description: This is the official plugin, that allows you to choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. Furthermore, you can also submit all your orders to Packeta with just one click.
  * Version: 1.2.0
  * Author: Zásilkovna s.r.o.
  * Author URI: https://www.zasilkovna.cz/

--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -7,17 +7,16 @@
  * @wordpress-plugin
  *
  * Plugin Name: Packeta
- * Description: With the help of our official plugin, You can choose pickup points of Packeta and it's external carriers in all of Europe, or utilize address delivery for 25 countries in the European Union, straight from the cart in Your eshop. You can submit all of Your orders to Packeta with one click.
+ * Description: With the help of our official plugin, You can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in Your e-shop. You can also submit all your orders to Packeta with just one click.
  * Version: 1.2.0
  * Author: Zásilkovna s.r.o.
  * Author URI: https://www.zasilkovna.cz/
  * Text Domain: packetery
  * Domain Path: /languages
- * Requires at least: 5.3
+ * Requires at least: WordPress 5.3, WooCommerce 4.5
+ * Tested up to: WordPress 5.9.2, WooCommerce 6.3.1
  * Requires PHP: 7.2
  *
- * WC requires at least: 4.5
- * WC tested up to: 6.1.1
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -13,10 +13,12 @@
  * Author URI: https://www.zasilkovna.cz/
  * Text Domain: packetery
  * Domain Path: /languages
- * Requires at least: WordPress 5.3, WooCommerce 4.5
- * Tested up to: WordPress 5.9.2, WooCommerce 6.3.1
+ * Requires at least: 5.3
  * Requires PHP: 7.2
  *
+ * WP Tested up to: 5.9.2
+ * WC requires at least: 4.5
+ * WC tested up to: 6.3.1
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/packetery/readme.txt
+++ b/packetery/readme.txt
@@ -10,7 +10,7 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 == Description ==
 
-With the help of our official plugin, you can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. You can also submit all your orders to Packeta with just one click.
+This is the official plugin, with which you can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. Furthermore, you can also submit all your orders to Packeta with just one click.
 
 = Plugin functions: =
 

--- a/packetery/readme.txt
+++ b/packetery/readme.txt
@@ -38,7 +38,7 @@ This is the official plugin, that allows you to choose pickup points of Packeta 
 
 == Installation ==
 
-* You can install the plugin either in your WordPress administration: Plugins->Plugin installation->Upload plugin or upload the "packetery" file into the /wp-content/plugins/ 
+* You can install the plugin either in your WordPress administration: Plugins->Plugin installation->Upload plugin or upload the "packetery" folder into the /wp-content/plugins/ 
 * Activate the plugin in the WordPress menu "Plugins"
 * Set up the plugin according to our user documentation
 

--- a/packetery/readme.txt
+++ b/packetery/readme.txt
@@ -8,13 +8,13 @@ Requires PHP: 7.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-With the help of our official plugin, You can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in Your e-shop. You can also submit all your orders to Packeta with just one click.
+With the help of our official plugin, you can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. You can also submit all your orders to Packeta with just one click.
 
 == Description ==
 
 = Plugin functions: =
 
-* the ability to choose a pickup place in Your cart using our widget v6
+* the ability to choose a pickup place in your cart using our widget v6
 * the ability to change the destination pickup point of an existing order
 * the option to allow checkout address validation using our widget HD
 * delivery to Packeta pickup places (Czech Republic, Slovakian Republic, Hungary, and Romania)
@@ -36,7 +36,7 @@ With the help of our official plugin, You can choose pickup points of Packeta an
 
 == Installation ==
 
-* You can install the plugin either in Your WordPress administration: Plugins->Plugin installation->Upload plugin or upload the "packetery" file into the /wp-content/plugins/ 
+* You can install the plugin either in your WordPress administration: Plugins->Plugin installation->Upload plugin or upload the "packetery" file into the /wp-content/plugins/ 
 * Activate the plugin in the WordPress menu "Plugins"
 * Set up the plugin according to our user documentation
 
@@ -52,7 +52,7 @@ In order to be able to use modern development procedures and continue to expand 
 
 = I'm missing a feature I would like to see, what should I do? =
 
-We are constantly working on adding new features. You can find a list of features we are currently working on in the "You can look forward to" chapter. If there is a feature You would like to see added, that is missing in our list, then please contact us at technicka.podpora@zasilkovna.cz
+We are constantly working on adding new features. You can find a list of features we are currently working on in the "You can look forward to" chapter. If there is a feature you would like to see added, that is missing in our list, then please contact us at technicka.podpora@zasilkovna.cz
 
 = I have found a mistake in the plugin or need help with the installation or set up of the plugin. =
 

--- a/packetery/readme.txt
+++ b/packetery/readme.txt
@@ -8,9 +8,9 @@ Requires PHP: 7.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-With the help of our official plugin, you can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. You can also submit all your orders to Packeta with just one click.
-
 == Description ==
+
+With the help of our official plugin, you can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. You can also submit all your orders to Packeta with just one click.
 
 = Plugin functions: =
 

--- a/packetery/readme.txt
+++ b/packetery/readme.txt
@@ -10,7 +10,7 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 == Description ==
 
-This is the official plugin, with which you can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. Furthermore, you can also submit all your orders to Packeta with just one click.
+This is the official plugin, that allows you to choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. Furthermore, you can also submit all your orders to Packeta with just one click.
 
 = Plugin functions: =
 

--- a/packetery/readme.txt
+++ b/packetery/readme.txt
@@ -1,56 +1,44 @@
 === Packeta ===
 Contributors: packeta
 Tags: WooCommerce, shipping
-Requires at least: 5.3
-Tested up to: 5.8.3
+Requires at least: WordPress 5.3, WooCommerce 4.5
+Tested up to: WordPress 5.9.2, WooCommerce 6.3.1
 Stable tag: 1.2.0
 Requires PHP: 7.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-With the help of our official plugin, You can choose pickup points of Packeta and it's external carriers in all of Europe, or utilize address delivery for 25 countries in the European Union, straight from the cart in Your eshop. You can submit all of Your orders to Packeta with one click.
+With the help of our official plugin, You can choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in Your e-shop. You can also submit all your orders to Packeta with just one click.
 
 == Description ==
 
 = Plugin functions: =
 
 * the ability to choose a pickup place in Your cart using our widget v6
-* delivery to Packeta pickup places (Czech republic, Slovakian republic, Hungary and Romania)
+* the ability to change the destination pickup point of an existing order
+* the option to allow checkout address validation using our widget HD
+* delivery to Packeta pickup places (Czech Republic, Slovakian Republic, Hungary, and Romania)
 * delivery to pickup places of carriers all around Europe
 * the ability to add/modify the packet weight and dimensions before submitting the packet to Packeta
 * automatic sending of orders to Packeta with one click
 * each delivery sent to Packeta will automatically show the tracking number with a link to a website with the shipment tracking
 * the printing of labels, including direct carrier labels
+* printing of shipment lists (AWB)
+* 18+ age verification setting for your products
 
 = You can look forward to: =
 
 * automatically updated information on the current packet status
 * the ability to automatically change the order status according to the packet status
-* the filling out of customs declarations and shipping of packets to countries outside of EU
+* the filling out of customs declarations and shipping of packets to countries outside of the EU
 * the creation of claim assistant packets
-* printing of shipment lists
-* the ability to change the pickup place of an already existing packet
-* the option to choose a pickup place during the manual creation of the packet in administration
+* the option to choose a pickup place during the manual creation of the packet in the administration
 
 == Installation ==
 
-* You can install the plugin in Your Wordpress administration: Plugins->Plugin installation->Upload plugin
+* You can install the plugin either in Your WordPress administration: Plugins->Plugin installation->Upload plugin or upload the "packetery" file into the /wp-content/plugins/ 
 * Activate the plugin in the WordPress menu "Plugins"
-
-= Setting up of the module in WordPress Administration: =
-
-* In the Packeta>Settings menu. Fill in the API password, sender, pick the label format and choose the payment method for cash on delivery.
-* In the Packeta>Carrier settings menu, first update the list of carriers and countries, by clicking on the "Update the carrier list" button.
-* In the Packeta>Carrier settings menu, choose the country, to which You want to deliver packets using Packeta and press the "Set up" button
-* For each carrier fill out the following:
- * the name of the carrier in Your cart
- * the weight parameters (at least one)
- * payment for cash on delivery option (it is not required to fill out, if You don't charge a cash on delivery fee)
- * the limit for free delivery
-* You can set the carrier as active by ticking the "Active carrier" box
-* Save the changes by clicking the "Save changes" button. Each carrier settings have to be saved separately.
-* In the WooCommerce>Settings>Delivery menu, either add to an existing zone or create a new one and as the delivery service choose the "Packeta Delivery Service" option
-* If Your e-shop offers products which are considered "Adult only", then in the product details in the "Packeta" tab tick the "Age verification 18+" option. If there is at least one product in the order marked as needing age verification, then this information will be sent to Packeta during the packet creation. Age verification can be used only for packets sent to Packeta pickup places (Czech republic, Slovakian republic, Hungary and Romania).
+* Set up the plugin according to our user documentation
 
 == Frequently Asked Questions ==
 
@@ -58,7 +46,7 @@ With the help of our official plugin, You can choose pickup points of Packeta an
 
 Yes. All functions of our plugin are completely free. No need to purchase any premium extensions.
 
-= What are the minimal required versions of WordPress and PHP? =
+= What are the minimum required versions of WordPress and PHP? =
 
 In order to be able to use modern development procedures and continue to expand the functions of the plugin, it is necessary to run the plugin on WordPress 5.3+ and PHP 7.2 - 7.4. The plugin does not currently support PHP 8
 
@@ -66,90 +54,89 @@ In order to be able to use modern development procedures and continue to expand 
 
 We are constantly working on adding new features. You can find a list of features we are currently working on in the "You can look forward to" chapter. If there is a feature You would like to see added, that is missing in our list, then please contact us at technicka.podpora@zasilkovna.cz
 
-= I have found a mistake in the plugin or need help with the installation or setting up of the plugin. =
+= I have found a mistake in the plugin or need help with the installation or set up of the plugin. =
 
 Please contact us at technicka.podpora@zasilkovna.cz .
 
 == Changelog ==
 = 1.2.0 =
-* Updated: Packeta shipping method name updated and description removed
+* Added: Primary key for carrier table
 * Updated: Packeta order meta data moved from posts to custom table
-* Updated: logger uses custom database table
+* Updated: Logger uses custom database table
+* Updated: Only 3 decimal places are accepted for order weight
+* Updated: JavaScript and CSS files are now loading conditionally
 * Fixed: Packeta checkout validators now trigger only if Packeta shipping is selected
-* Added: primary key for carrier table
-* Fixed: label print page now shows the correct number of labels that will be printed
-* Fixed: widget button now shows even if no country was selected on checkout page load
-* Fixed: javascript dependencies added where missing
-* Fixed: non-Packeta order submit to Packeta API no longer creates PHP error
-* Fixed: label printing now accepts trashed orders
+* Fixed: Label print page now shows the correct number of labels that will be printed
+* Fixed: Widget button now shows even if no country was selected on checkout page load
+* Fixed: Javascript dependencies added where missing
+* Fixed: Non-Packeta order submission to Packeta API no longer creates PHP error
+* Fixed: Label printing now accepts trashed orders
 * Fixed: Packeta order modal now dynamically calculates weight if no weight is provided
 * Fixed: Packeta logger now supports emote characters
-* Updated: only 3 decimal places are accepted for order weight
-* Updated: JavaScript and CSS files are now loading conditionally
-* Fixed: deactivating WooCommerce plugin while having Packeta plugin activated no longer crashes entire site
+* Fixed: Deactivating WooCommerce plugin while having Packeta plugin activated no longer crashes the entire site
 
 = 1.1.1 =
-* Fixed: overweight orders now never have shipping for free
-* Fixed: packet API submissions now always include order currency
+* Fixed: Overweight orders now never have shipping for free
+* Fixed: Packet API submissions now always include order currency
 
 = 1.1.0 =
-* Added: Information about the count of printed labels and "back" link added to label offset setting form.
-* Added: Possibility to print the same labels again in single session in label print page.
-* Added: Possibility to print single label from order list.
-* Added: Possibility to submit single order to Packeta from order list.
-* Added: Admin pickup point picker in order detail.
-* Added: Packaging weight in plugin settings.
-* Added: Checkout address validation.
-* Added: Possibility to edit order weight in order list.
-* Added: List of active carriers added to carrier settings section.
-* Added: Order collection printing.
-* Added: Sender verification in plugin settings.
-* Added: SK translation.
-* Updated: Carrier settings interface.
-* Updated: Packetery buttons in order list.
-* Updated: Flash messages are always first in message stack.
+* Added: Information about the count of printed labels and "back" link added to label offset setting form
+* Added: Possibility to print the same labels again in a single session in the label print page
+* Added: Possibility to print single label from order list
+* Added: Possibility to submit single order to Packeta from order list
+* Added: Admin pickup point picker in order detail
+* Added: Packaging weight in plugin settings
+* Added: Checkout address validation
+* Added: Possibility to edit order weight in order list
+* Added: List of active carriers added to carrier settings section
+* Added: Shipment lists printing
+* Added: Sender verification in plugin settings
+* Added: SK translation
+* Updated: Carrier settings interface
+* Updated: Packetery buttons in order list
+* Updated: Flash messages are always first in message stack
 
 = 1.0.7 =
-* Fixed: the label print page displays a message to the user if no suitable orders are selected
-* Fixed: Some environments caused error due PHPDocs being removed by OPCache.
-* Fixed: Order list filters can now be combined.
+* Fixed: The label print page displays a message to the user if no suitable orders are selected
+* Fixed: Some environments caused error due PHPDocs being removed by OPCache
+* Fixed: Order list filters can now be combined
 
 = 1.0.6 =
-* Updated: carrier settings page errors highlighted
-* Added: default C.O.D. surcharge
-* Fixed: only available payment methods are available for selection in plugin settings
-* Added: COD surcharge was separated from shipping cost and is shown in order fees
+* Added: Default cash-on-delivery surcharge
+* Added: Cash-on-delivery surcharge was separated from shipping cost and is shown in order fees during checkout
+* Updated: Carrier settings page errors highlighted
+* Fixed: Only available payment methods are available for selection in plugin settings
 
 = 1.0.5 =
-* Update: sender description
-* Fixed: cash on delivery payment method is always available for selection in Packeta plugin settings
-* Fixed: checkout refresh on payment method change happens only if value really changes
+* Updated: Sender description
+* Fixed: Cash-on-delivery payment method is always available for selection in Packeta plugin settings
+* Fixed: Checkout refresh on payment method change happens only if the value really changes
 
 = 1.0.4 =
-* Fixed: inputs in the cart implemented so as not to affect the appearance
+* Added: If the creation of the carrier table fails, the user is informed and error is logged
+* Updated: Settings export expanded to be even more helpful
+* Fixed: Inputs in the cart implemented so as not to affect the appearance
 * Fixed: Packeta logo CSS in cart made simple and compatible
-* Updated: Settings export extended to be even more helpful.
-* Added: if the creation of the carrier table fails, the user is informed and error is logged
-* Removed: dependency on intl library
+* Removed: Dependency on intl library
 
 = 1.0.3 =
-* Fixed: use of pickup point method in cart with billing only setting enabled
+* Fixed: Use of pickup point method in cart with billing only setting enabled
 
 = 1.0.2 =
-* Fixed: broken relative URLs in multiple places
+* Fixed: Broken relative URLs in multiple places
 
 = 1.0.1 =
-* Fixed: user no longer sees messages from other sessions
-* Updated: logger no longer deletes older records
-* Fixed: logger handles double quotes in error messages
-* Fixed: corrected count of orders in filtering links.
-* Fixed: save carrier's maximum weight correctly as float.
-* Fixed: carrier name input width css rule to cover all carriers.
-* Fixed: pickup point id will be stored as a string, because external carriers may require it.
-* Fixed: exception handling during CreatePacket API call - faultstring used when no detail property is returned
-* Added: Settings export to help solve various issues.
-* Fixed: CLI error. Plugin now does not bootstrap in CLI environment.
-* Fixed: Exception when HTTP response headers are already sent. Plugin now does not bootstrap in such case.
+* Added: Settings export to help solve various issues
+* Updated: Logger no longer deletes older records
+* Fixed: User no longer sees messages from other sessions
+* Fixed: Logger handles double quotes in error messages
+* Fixed: Corrected the count of orders in filtering links
+* Fixed: Save carrier's maximum weight correctly as a float
+* Fixed: Carrier name input width css rule to cover all carriers
+* Fixed: Pickup point id will be stored as a string, because external carriers may require it
+* Fixed: Exception handling during CreatePacket API call - faultstring used when no detail property is returned
+* Fixed: CLI error - plugin now does not bootstrap in CLI environment
+* Fixed: Exception when HTTP response headers are already sent - Plugin now does not bootstrap in such case
 
 = 1.0.0 =
 * Initial version

--- a/packetery/readme.txt
+++ b/packetery/readme.txt
@@ -1,10 +1,12 @@
 === Packeta ===
 Contributors: packeta
 Tags: WooCommerce, shipping
-Requires at least: WordPress 5.3, WooCommerce 4.5
-Tested up to: WordPress 5.9.2, WooCommerce 6.3.1
+Requires at least: 5.3
+Tested up to: 5.9.2
 Stable tag: 1.2.0
 Requires PHP: 7.2
+WC requires at least: 4.5
+WC tested up to: 6.3.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
packetery.php
  * Updated WC and WP versions + slight description change

readme.txt
 * Grammar corrections
 * Added current WC and WP versions
 * Unified format of changelogs and the order of types of changes (added-updated-fixed-removed)
 * Expanded Plugin functions according to documentation
 * Removed completed features from "You can look forward to"
 * Removed the "Setting up of the module in WordPress Administration:" section - will be replaced by a link to our user documentation when available