### PR TITLE
Pes 693 deleting orders

### DIFF
--- a/src/Packetery/Module/Order/Repository.php
+++ b/src/Packetery/Module/Order/Repository.php
@@ -17,6 +17,7 @@ use Packetery\Module\Calculator;
 use Packetery\Module\Carrier;
 use Packetery\Module\Product;
 use Packetery\Module\ShippingMethod;
+use WP_Post;
 
 /**
  * Class Repository.
@@ -432,4 +433,32 @@ class Repository {
 			WHERE o.`packet_id` IS NOT NULL AND o.`is_label_printed` = false'
 		);
 	}
+
+	/**
+	 * Deletes data from custom table.
+	 *
+	 * @param int $orderId Order id.
+	 *
+	 * @return void
+	 */
+	private function delete( int $orderId ): void {
+		$wpdb = $this->wpdb;
+
+		$wpdb->delete( $wpdb->packetery_order, [ 'id' => $orderId ], '%d' );
+	}
+
+	/**
+	 * Fires after post deletion.
+	 *
+	 * @param int     $postId Post id.
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return void
+	 */
+	public function deletedPostHook( int $postId, WP_Post $post ): void {
+		if ( 'shop_order' === $post->post_type ) {
+			$this->delete( $postId );
+		}
+	}
+
 }

--- a/src/Packetery/Module/Order/Repository.php
+++ b/src/Packetery/Module/Order/Repository.php
@@ -435,6 +435,21 @@ class Repository {
 	}
 
 	/**
+	 * Deletes all custom table records linked to permanently deleted orders.
+	 *
+	 * @return void
+	 */
+	public function deleteOrphans(): void {
+		$wpdb = $this->wpdb;
+
+		$wpdb->query(
+			'DELETE `' . $wpdb->packetery_order . '` FROM `' . $wpdb->packetery_order . '`
+			LEFT JOIN `' . $wpdb->posts . '` ON `' . $wpdb->posts . '`.`ID` = `' . $wpdb->packetery_order . '`.`id`
+			WHERE `' . $wpdb->posts . '`.`ID` IS NULL'
+		);
+	}
+
+	/**
 	 * Deletes data from custom table.
 	 *
 	 * @param int $orderId Order id.

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -386,6 +386,8 @@ class Plugin {
 
 		add_action( 'admin_init', [ $this->exporter, 'outputExportTxt' ] );
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', [ $this, 'transformGetOrdersQuery' ] );
+
+		add_action( 'deleted_post', [ $this->orderRepository, 'deletedPostHook' ], 10, 2 );
 	}
 
 	/**

--- a/src/Packetery/Module/Upgrade.php
+++ b/src/Packetery/Module/Upgrade.php
@@ -130,6 +130,11 @@ class Upgrade {
 			unregister_post_type( self::POST_TYPE_VALIDATED_ADDRESS );
 		}
 
+		// TODO 693 use proper version.
+		if ( $oldVersion && version_compare( $oldVersion, '1.2.6', '<' ) ) {
+			$this->orderRepository->deleteOrphans();
+		}
+
 		update_option( 'packetery_version', Plugin::VERSION );
 	}
 

--- a/src/Packetery/Module/Upgrade.php
+++ b/src/Packetery/Module/Upgrade.php
@@ -130,7 +130,6 @@ class Upgrade {
 			unregister_post_type( self::POST_TYPE_VALIDATED_ADDRESS );
 		}
 
-		// TODO 693 use proper version.
 		if ( $oldVersion && version_compare( $oldVersion, '1.2.6', '<' ) ) {
 			$this->orderRepository->deleteOrphans();
 		}


### PR DESCRIPTION
Fixed: delete order from custom table after deleting woocommerce order
Fixed: delete all custom table records linked to permanently deleted orders