### PR TITLE
[Checkout/Repository] Added extra filter hooks to enable shipping method manipulations

### DIFF
--- a/src/Packetery/Module/Carrier/Repository.php
+++ b/src/Packetery/Module/Carrier/Repository.php
@@ -117,7 +117,7 @@ class Repository {
 			array_unshift( $carriers, $zpointCarrier );
 		}
 
-		return $carriers;
+		return apply_filters( 'packeta_all_carriers', $carriers );
 	}
 
 	/**

--- a/src/Packetery/Module/Checkout.php
+++ b/src/Packetery/Module/Checkout.php
@@ -322,7 +322,7 @@ class Checkout {
 			}
 		}
 
-		return [
+		return apply_filters( 'packeta_checkout_settings', [
 			/**
 			 * Filter widget language in checkout.
 			 *
@@ -348,7 +348,7 @@ class Checkout {
 				'addressIsNotValidated'         => __( 'Delivery address has not been verified.', 'packeta' ),
 				'addressIsNotValidatedAndRequiredByCarrier' => __( 'Delivery address has not been verified. Verification of delivery address is required by this carrier.', 'packeta' ),
 			],
-		];
+		] );
 	}
 
 	/**
@@ -739,7 +739,7 @@ class Checkout {
 			}
 		}
 
-		return $customRates;
+		return apply_filters( 'packeta_shipping_rates', $customRates );
 	}
 
 	/**


### PR DESCRIPTION
Hello,

made these changes because its always nice to have a way to manipulate with the shipping methods before you display them in checkout.

Adding those 3 filters enables a lot for developers but does not break anything for those who just don't want to use them.

Thanks.

