### PR TITLE
PES-1612: Jazyk pluginu na BE nerespektuje nastavení jazyku v uživatelském profilu

### DIFF
--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -930,13 +930,14 @@ class Plugin {
 	 */
 	public function loadTranslation(): void {
 		$domain = self::DOMAIN;
+		unload_textdomain( $domain );
 		$locale = self::getLocale();
 		$moFile = WP_LANG_DIR . "/plugins/$domain-$locale.mo";
 
 		if ( file_exists( $moFile ) ) {
-			load_textdomain( $domain, $moFile, $locale );
+			load_plugin_textdomain( $domain );
 		} else {
-			unload_textdomain( $domain );
+			load_default_textdomain();
 		}
 	}
 

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -24,6 +24,7 @@ use Packetery\Nette\Http\Request;
 use Packetery\Nette\Utils\Html;
 use WC_Email;
 use WC_Order;
+use function Packetery\bdump;
 
 /**
  * Class Plugin
@@ -388,12 +389,7 @@ class Plugin {
 	 * Method to register hooks
 	 */
 	public function run(): void {
-		add_action(
-			'init',
-			function (): void {
-				load_plugin_textdomain( self::DOMAIN );
-			}
-		);
+		add_action( 'init', [ $this, 'loadTranslation' ] );
 
 		if ( ! self::isWooCommercePluginActive() ) {
 			add_action( 'admin_notices', [ $this, 'echoInactiveWooCommerceNotice' ] );
@@ -928,6 +924,22 @@ class Plugin {
 			( is_admin() ? get_user_locale() : get_locale() ),
 			self::DOMAIN
 		);
+	}
+
+	/**
+	 * Loads plugin translation file by user locale.
+	 */
+	public function loadTranslation(): void {
+		$domain = self::DOMAIN;
+		$locale = self::getLocale();
+		$moFile = WP_LANG_DIR . "/plugins/$domain-$locale.mo";
+
+		if ( file_exists( $moFile ) ) {
+			load_textdomain( $domain, $moFile, $locale );
+		} else {
+			unload_textdomain( $domain );
+			load_default_textdomain();
+		}
 	}
 
 	/**

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -933,12 +933,7 @@ class Plugin {
 		$locale = self::getLocale();
 		$moFile = WP_LANG_DIR . "/plugins/$domain-$locale.mo";
 
-		$plugin = load_plugin_textdomain( $domain, false, $moFile );
-
-		if ( false === $plugin ) {
-			$moFile = WP_LANG_DIR . "/plugins/$domain-en_US.mo";
-			load_plugin_textdomain( $domain, false, $moFile );
-		}
+		load_plugin_textdomain( $domain, false, $moFile );
 	}
 
 	/**

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -388,7 +388,12 @@ class Plugin {
 	 * Method to register hooks
 	 */
 	public function run(): void {
-		add_action( 'init', [ $this, 'loadTranslation' ] );
+		add_action(
+			'init',
+			function (): void {
+				load_plugin_textdomain( self::DOMAIN );
+			}
+		);
 
 		if ( ! self::isWooCommercePluginActive() ) {
 			add_action( 'admin_notices', [ $this, 'echoInactiveWooCommerceNotice' ] );
@@ -923,15 +928,6 @@ class Plugin {
 			( is_admin() ? get_user_locale() : get_locale() ),
 			self::DOMAIN
 		);
-	}
-
-	/**
-	 * Loads plugin translation file by user locale.
-	 */
-	public function loadTranslation(): void {
-		$domain = self::DOMAIN;
-
-		load_plugin_textdomain( $domain );
 	}
 
 	/**

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -930,12 +930,8 @@ class Plugin {
 	 */
 	public function loadTranslation(): void {
 		$domain = self::DOMAIN;
-		$locale = self::getLocale();
-		$moFile = WP_LANG_DIR . "/plugins/$domain-$locale.mo";
 
-		if ( file_exists( $moFile ) ) {
-			load_plugin_textdomain( $domain, false, $moFile );
-		}
+		load_plugin_textdomain( $domain );
 	}
 
 	/**

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -414,7 +414,6 @@ class Plugin {
 		);
 		add_action( 'init', array( $this, 'init' ) );
 
-		// TODO: deactivation_hook.
 		register_deactivation_hook(
 			$this->main_file_path,
 			static function () {
@@ -931,13 +930,13 @@ class Plugin {
 	public function loadTranslation(): void {
 		$domain = self::DOMAIN;
 		$locale = self::getLocale();
+		$moFile = WP_LANG_DIR . "/plugins/$domain-$locale.mo";
 
-		$moFile = PACKETERY_PLUGIN_DIR . "/languages/$domain-$locale.mo";
-		$result = load_textdomain( $domain, $moFile );
+		$plugin = load_plugin_textdomain( $domain, false, $moFile );
 
-		if ( false === $result ) {
-			$moFile = PACKETERY_PLUGIN_DIR . "/languages/$domain-en_US.mo";
-			load_textdomain( $domain, $moFile );
+		if ( false === $plugin ) {
+			$moFile = WP_LANG_DIR . "/plugins/$domain-en_US.mo";
+			load_plugin_textdomain( $domain, false, $moFile );
 		}
 	}
 

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -933,7 +933,9 @@ class Plugin {
 		$locale = self::getLocale();
 		$moFile = WP_LANG_DIR . "/plugins/$domain-$locale.mo";
 
-		load_plugin_textdomain( $domain, false, $moFile );
+		if ( file_exists( $moFile ) ) {
+			load_plugin_textdomain( $domain, false, $moFile );
+		}
 	}
 
 	/**

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -24,7 +24,6 @@ use Packetery\Nette\Http\Request;
 use Packetery\Nette\Utils\Html;
 use WC_Email;
 use WC_Order;
-use function Packetery\bdump;
 
 /**
  * Class Plugin

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -937,7 +937,6 @@ class Plugin {
 			load_textdomain( $domain, $moFile, $locale );
 		} else {
 			unload_textdomain( $domain );
-			load_default_textdomain();
 		}
 	}
 

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -414,6 +414,7 @@ class Plugin {
 		);
 		add_action( 'init', array( $this, 'init' ) );
 
+		// TODO: deactivation_hook.
 		register_deactivation_hook(
 			$this->main_file_path,
 			static function () {


### PR DESCRIPTION
Bug: Fixed the path to translations located in the WP folder, where the translations are being generated.