### PR TITLE
PES-1634: Před použítím funkce as_has_scheduled_action otestovat, že funkce existuje

### DIFF
--- a/src/Packetery/Module/CronService.php
+++ b/src/Packetery/Module/CronService.php
@@ -66,7 +66,7 @@ class CronService {
 			'init',
 			function () {
 				add_action( self::CRON_LOG_AUTO_DELETION_HOOK, [ $this->logPurger, 'autoDeleteHook' ] );
-				if ( false === as_has_scheduled_action( self::CRON_LOG_AUTO_DELETION_HOOK ) ) {
+				if ( function_exists( 'as_has_scheduled_action' ) && false === as_has_scheduled_action( self::CRON_LOG_AUTO_DELETION_HOOK ) ) {
 					as_schedule_recurring_action( ( new \DateTime( 'next day 02:00', wp_timezone() ) )->getTimestamp(), DAY_IN_SECONDS, self::CRON_LOG_AUTO_DELETION_HOOK );
 				}
 			}
@@ -76,7 +76,7 @@ class CronService {
 			'init',
 			function () {
 				add_action( self::CRON_CARRIERS_HOOK, [ $this->carrierDownloader, 'runAndRender' ] );
-				if ( false === as_has_scheduled_action( self::CRON_CARRIERS_HOOK ) ) {
+				if ( function_exists( 'as_has_scheduled_action' ) && false === as_has_scheduled_action( self::CRON_CARRIERS_HOOK ) ) {
 					as_schedule_recurring_action( ( new \DateTime( 'next day 09:10', wp_timezone() ) )->getTimestamp(), DAY_IN_SECONDS, self::CRON_CARRIERS_HOOK );
 				}
 			}
@@ -86,7 +86,7 @@ class CronService {
 			'init',
 			function () {
 				add_action( self::CRON_PACKET_STATUS_SYNC_HOOK, [ $this->packetSynchronizer, 'syncStatuses' ] );
-				if ( false === as_has_scheduled_action( self::CRON_PACKET_STATUS_SYNC_HOOK ) ) {
+				if ( function_exists( 'as_has_scheduled_action' ) && false === as_has_scheduled_action( self::CRON_PACKET_STATUS_SYNC_HOOK ) ) {
 					// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 					// Monday to Friday at 02:10, 06:10, 10:10, 14:10, 18:10, 22:10.
 					as_schedule_cron_action( ( new \DateTime() )->getTimestamp(), '10 2,6,10,14,18,22 * * 1-5', self::CRON_PACKET_STATUS_SYNC_HOOK );
@@ -98,7 +98,7 @@ class CronService {
 			'init',
 			function () {
 				add_action( self::CRON_PACKET_STATUS_SYNC_HOOK_WEEKEND, [ $this->packetSynchronizer, 'syncStatuses' ] );
-				if ( false === as_has_scheduled_action( self::CRON_PACKET_STATUS_SYNC_HOOK_WEEKEND ) ) {
+				if ( function_exists( 'as_has_scheduled_action' ) && false === as_has_scheduled_action( self::CRON_PACKET_STATUS_SYNC_HOOK_WEEKEND ) ) {
 					// Saturday, Sunday at 03:10.
 					as_schedule_cron_action( ( new \DateTime() )->getTimestamp(), '10 3 * * 6,0', self::CRON_PACKET_STATUS_SYNC_HOOK_WEEKEND );
 				}

--- a/src/Packetery/Module/CronService.php
+++ b/src/Packetery/Module/CronService.php
@@ -62,11 +62,15 @@ class CronService {
 	 * @return void
 	 */
 	public function register(): void {
+		if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+
 		add_action(
 			'init',
 			function () {
 				add_action( self::CRON_LOG_AUTO_DELETION_HOOK, [ $this->logPurger, 'autoDeleteHook' ] );
-				if ( function_exists( 'as_has_scheduled_action' ) && false === as_has_scheduled_action( self::CRON_LOG_AUTO_DELETION_HOOK ) ) {
+				if ( false === as_has_scheduled_action( self::CRON_LOG_AUTO_DELETION_HOOK ) ) {
 					as_schedule_recurring_action( ( new \DateTime( 'next day 02:00', wp_timezone() ) )->getTimestamp(), DAY_IN_SECONDS, self::CRON_LOG_AUTO_DELETION_HOOK );
 				}
 			}
@@ -76,7 +80,7 @@ class CronService {
 			'init',
 			function () {
 				add_action( self::CRON_CARRIERS_HOOK, [ $this->carrierDownloader, 'runAndRender' ] );
-				if ( function_exists( 'as_has_scheduled_action' ) && false === as_has_scheduled_action( self::CRON_CARRIERS_HOOK ) ) {
+				if ( false === as_has_scheduled_action( self::CRON_CARRIERS_HOOK ) ) {
 					as_schedule_recurring_action( ( new \DateTime( 'next day 09:10', wp_timezone() ) )->getTimestamp(), DAY_IN_SECONDS, self::CRON_CARRIERS_HOOK );
 				}
 			}
@@ -86,7 +90,7 @@ class CronService {
 			'init',
 			function () {
 				add_action( self::CRON_PACKET_STATUS_SYNC_HOOK, [ $this->packetSynchronizer, 'syncStatuses' ] );
-				if ( function_exists( 'as_has_scheduled_action' ) && false === as_has_scheduled_action( self::CRON_PACKET_STATUS_SYNC_HOOK ) ) {
+				if ( false === as_has_scheduled_action( self::CRON_PACKET_STATUS_SYNC_HOOK ) ) {
 					// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 					// Monday to Friday at 02:10, 06:10, 10:10, 14:10, 18:10, 22:10.
 					as_schedule_cron_action( ( new \DateTime() )->getTimestamp(), '10 2,6,10,14,18,22 * * 1-5', self::CRON_PACKET_STATUS_SYNC_HOOK );
@@ -98,7 +102,7 @@ class CronService {
 			'init',
 			function () {
 				add_action( self::CRON_PACKET_STATUS_SYNC_HOOK_WEEKEND, [ $this->packetSynchronizer, 'syncStatuses' ] );
-				if ( function_exists( 'as_has_scheduled_action' ) && false === as_has_scheduled_action( self::CRON_PACKET_STATUS_SYNC_HOOK_WEEKEND ) ) {
+				if ( false === as_has_scheduled_action( self::CRON_PACKET_STATUS_SYNC_HOOK_WEEKEND ) ) {
 					// Saturday, Sunday at 03:10.
 					as_schedule_cron_action( ( new \DateTime() )->getTimestamp(), '10 3 * * 6,0', self::CRON_PACKET_STATUS_SYNC_HOOK_WEEKEND );
 				}


### PR DESCRIPTION
Sanitised all occurrences of as_has_scheduled_action() to ensure the script only runs, when the function exists.