### PR TITLE
PES-2077: Undefined array key new carrier settings enabled

### DIFF
--- a/src/Packetery/Module/Options/Provider.php
+++ b/src/Packetery/Module/Options/Provider.php
@@ -614,7 +614,7 @@ class Provider {
 	 * @return bool
 	 */
 	public function isWcCarrierConfigEnabled(): bool {
-		$isEnabled = $this->advancedData['new_carrier_settings_enabled'];
+		$isEnabled = ( $this->advancedData['new_carrier_settings_enabled'] ?? null );
 		if ( null !== $isEnabled ) {
 			return (bool) $isEnabled;
 		}


### PR DESCRIPTION
Fixed the error that occurs when the new settings option is not saved in the database.