### PR TITLE
PES-2282: Add GitHub action for PHPUnit tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     name: New release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2 # https://github.com/actions/checkout/releases/tag/v2

--- a/.github/workflows/run-phpstan.yml
+++ b/.github/workflows/run-phpstan.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   phpstan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/.github/workflows/run-phpunit.yml
+++ b/.github/workflows/run-phpunit.yml
@@ -1,0 +1,38 @@
+name: PHPUnit tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: ['8.3']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, intl
+          coverage: yes
+
+      - name: php version
+        run: php -v
+
+      - name: Install Composer dependencies
+        run: composer install
+
+      - name: Install Composer dev dependencies
+        working-directory: phpstan
+        run: composer install
+
+      - name: Run PHPUnit
+        run: composer run phpunit

--- a/.github/workflows/run-phpunit.yml
+++ b/.github/workflows/run-phpunit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   phpstan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/.github/workflows/run-phpunit.yml
+++ b/.github/workflows/run-phpunit.yml
@@ -35,4 +35,4 @@ jobs:
         run: composer install
 
       - name: Run PHPUnit
-        run: composer run phpunit
+        run: composer run tests-unit

--- a/.github/workflows/run-sniffer.yml
+++ b/.github/workflows/run-sniffer.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   sniff:
     name: Run sniffer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@master
       - name: Running sniffer

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpstan-81": "phpstan/vendor/bin/phpstan -cphpstan/php81.neon analyse",
         "phpstan-82": "phpstan/vendor/bin/phpstan -cphpstan/php82.neon analyse",
         "phpstan-83": "phpstan/vendor/bin/phpstan -cphpstan/php83.neon analyse",
-        "tests-unit": "./vendor/bin/phpunit tests",
+        "phpunit": "./vendor/bin/phpunit tests",
         "tests-coverage": "export XDEBUG_MODE=coverage && php -d memory_limit=200M ./vendor/bin/phpunit tests --coverage-html ./tests-coverage"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpstan-81": "phpstan/vendor/bin/phpstan -cphpstan/php81.neon analyse",
         "phpstan-82": "phpstan/vendor/bin/phpstan -cphpstan/php82.neon analyse",
         "phpstan-83": "phpstan/vendor/bin/phpstan -cphpstan/php83.neon analyse",
-        "phpunit": "./vendor/bin/phpunit tests",
+        "tests-unit": "./vendor/bin/phpunit tests",
         "tests-coverage": "export XDEBUG_MODE=coverage && php -d memory_limit=200M ./vendor/bin/phpunit tests --coverage-html ./tests-coverage"
     },
     "config": {

--- a/tests/Module/Carrier/OptionsPageTest.php
+++ b/tests/Module/Carrier/OptionsPageTest.php
@@ -8,6 +8,7 @@ use Packetery\Core\PickupPointProvider\CompoundCarrierCollectionFactory;
 use Packetery\Core\PickupPointProvider\VendorCollectionFactory;
 use Packetery\Latte\Engine;
 use Packetery\Module\Carrier\CarDeliveryConfig;
+use Packetery\Module\Carrier\CarrierOptionsFactory;
 use Packetery\Module\Carrier\CountryListingPage;
 use Packetery\Module\Carrier\EntityRepository;
 use Packetery\Module\Carrier\OptionsPage;
@@ -42,7 +43,8 @@ class OptionsPageTest extends TestCase {
 			$featureFlagMock
 		);
 
-		$optionsPage = new OptionsPage(
+		$carrierOptionsFactory   = $this->createMock( CarrierOptionsFactory::class );
+		$optionsPage             = new OptionsPage(
 			$latteEngineMock,
 			$carrierRepositoryMock,
 			$formFactoryMock,
@@ -53,6 +55,7 @@ class OptionsPageTest extends TestCase {
 			$featureFlagManagerMock,
 			$carDeliveryConfigMock,
 			$wcSettingsConfigMock,
+			$carrierOptionsFactory,
 		);
 
 		$featureFlagMock->method( 'isSplitActive' )->willReturn( true );

--- a/tests/Module/CheckoutTest.php
+++ b/tests/Module/CheckoutTest.php
@@ -17,6 +17,7 @@ use Packetery\Module\Framework\WpAdapter;
 use Packetery\Module\Options\Provider;
 use Packetery\Module\Order;
 use Packetery\Module\Order\PickupPointValidator;
+use Packetery\Module\Payment\PaymentHelper;
 use Packetery\Module\Product;
 use Packetery\Module\Product\ProductEntityFactory;
 use Packetery\Module\ProductCategory;
@@ -568,6 +569,7 @@ class CheckoutTest extends TestCase {
 			$carrierEntityRepository,
 			$this->createMock( Api\Internal\CheckoutRouter::class ),
 			$carDeliveryConfig,
+			$this->createMock(PaymentHelper::class),
 		);
 	}
 


### PR DESCRIPTION
Introduced a new GitHub action workflow for running PHPUnit tests on the main branch and for pull requests. Updated the composer script from 'tests-unit' to 'phpunit' for consistency with the new workflow.