### PR TITLE
PES-3270: release 2.3.1, fix stale VERSION constant

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 2.3.1 =
+Fixed: Database structure was not updated after updating the plugin.
+
 = 2.3.0 =
 Added: Option to display the consignment code in the order detail and on the printed parcel list.
 

--- a/packeta.php
+++ b/packeta.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Packeta
  * Description: This is the official plugin, that allows you to choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. Furthermore, you can also submit all your orders to Packeta with just one click.
- * Version: 2.3.0
+ * Version: 2.3.1
  * Author: Zásilkovna s.r.o.
  * Author URI: https://www.zasilkovna.cz/
  * Text Domain: packeta

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: packeta
 Tags: WooCommerce, shipping
 Requires at least: 6.3
 Tested up to: 7.0
-Stable tag: 2.3.0
+Stable tag: 2.3.1
 Requires PHP: 7.4
 WC requires at least: 5.1
 WC tested up to: 10.9.1
@@ -63,6 +63,9 @@ We are constantly working on adding new features. If there is a feature you woul
 Please contact us at e-commerce.support@packeta.com .
 
 == Changelog ==
+= 2.3.1 =
+Fixed: Database structure was not updated after updating the plugin.
+
 = 2.3.0 =
 Added: Option to display the consignment code in the order detail and on the printed parcel list.
 

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -19,7 +19,7 @@ use Packetery\Module\Hooks\HookRegistrar;
  */
 class Plugin {
 
-	public const VERSION                = '2.2.0';
+	public const VERSION                = '2.3.1';
 	public const DOMAIN                 = 'packeta';
 	public const PARAM_PACKETERY_ACTION = 'packetery_action';
 	public const PARAM_NONCE            = '_wpnonce';


### PR DESCRIPTION
## Kontext

Vydaná verze 2.3.0 šla na wp.org s `Plugin::VERSION` ponechanou na `2.2.0`. `Upgrade::check()` přeskočí migraci, když se uložená verze v DB rovná `Plugin::VERSION`, takže DB upgrade (`runCreateTables()`) po aktualizaci na 2.3.0 nikdy neproběhl.

Protože se `update_option(OptionNames::VERSION, …)` volá až po překročení early-returnu, u postižených webů zůstala uložená verze na `2.2.0` — díky tomu 2.3.1 spustí migraci pro všechny (jak pro ty, co na 2.3.0 přešli, tak pro ty, co ne).

## Změna

Bump na `2.3.1` na všech místech:
- `src/Packetery/Module/Plugin.php` — `const VERSION`
- `packeta.php` — hlavička `Version:`
- `readme.txt` — `Stable tag:` + changelog
- `changelog.txt` — nový záznam

## Poznámka

Na `main` je konstanta správně `2.3.0`, bug byl izolovaný na `v2.3`. Portování na `main` netřeba.