### PR TITLE
PES-3174: bump composer/composer to 2.9.8 (composer audit)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
         "php": "~8.1.0"
     },
     "require-dev": {
-        "composer/composer": "^2.9.3",
+        "composer/composer": "~2.9.8",
         "editorconfig-checker/editorconfig-checker": "^10.7",
         "ergebnis/composer-normalize": "^2.47",
         "php-stubs/woocommerce-stubs": "^10.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91ababc8eb0709541304b3c910e25381",
+    "content-hash": "bed6682b38a00c4629b722e87fd361d4",
     "packages": [],
     "packages-dev": [
         {
@@ -150,16 +150,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.9.5",
+            "version": "2.9.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "72a8f8e653710e18d83e5dd531eb5a71fc3223e6"
+                "reference": "39ee8baff8e97a1b657bbfcd6a236ff93a5efbb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/72a8f8e653710e18d83e5dd531eb5a71fc3223e6",
-                "reference": "72a8f8e653710e18d83e5dd531eb5a71fc3223e6",
+                "url": "https://api.github.com/repos/composer/composer/zipball/39ee8baff8e97a1b657bbfcd6a236ff93a5efbb2",
+                "reference": "39ee8baff8e97a1b657bbfcd6a236ff93a5efbb2",
                 "shasum": ""
             },
             "require": {
@@ -247,7 +247,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.9.5"
+                "source": "https://github.com/composer/composer/tree/2.9.8"
             },
             "funding": [
                 {
@@ -259,7 +259,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-29T10:40:53+00:00"
+            "time": "2026-05-13T07:28:38+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -8349,5 +8349,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
 Povýšení composer/composer 2.9.5 → 2.9.8 (dev-only)                                                                                                            
                                                                                         
  - kompatibilita ověřena:
    - statickými analýzami (phpstan core + module, phpcs, editorconfig, composer-normalize),
    - composer audit prochází bez --ignore (CVE-2026-40261/40176/45793 pryč)                                                                                                   
    -  E2E smoke + onboarding baseline zelené (wp-docker wp69)
    - Unit testy 540/540 OK na přesně PHP 8.1.0 (min. podporovaná verze)   
                                                                                                                                                                            
  - Není součástí DEPS: composer/composer je require-dev (build nástroj přes wpify/scoper), → regenerace  
  composer build:deps není potřeba.                                                                                          
                                                                                       