### PR TITLE
PES-3336: add missing external carriers, release 2.3.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 2.3.2 =
+Added: Romanian Post carriers (home delivery and pickup points).
+
 = 2.3.1 =
 Fixed: Database structure was not updated after updating the plugin.
 

--- a/packeta.php
+++ b/packeta.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Packeta
  * Description: This is the official plugin, that allows you to choose pickup points of Packeta and its external carriers in all of Europe, or utilize address delivery to 25 countries in the European Union, straight from the cart in your e-shop. Furthermore, you can also submit all your orders to Packeta with just one click.
- * Version: 2.3.1
+ * Version: 2.3.2
  * Author: Zásilkovna s.r.o.
  * Author URI: https://www.zasilkovna.cz/
  * Text Domain: packeta

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: packeta
 Tags: WooCommerce, shipping
 Requires at least: 6.3
 Tested up to: 7.0
-Stable tag: 2.3.1
+Stable tag: 2.3.2
 Requires PHP: 7.4
 WC requires at least: 5.1
 WC tested up to: 10.9.1
@@ -63,6 +63,9 @@ We are constantly working on adding new features. If there is a feature you woul
 Please contact us at e-commerce.support@packeta.com .
 
 == Changelog ==
+= 2.3.2 =
+Added: Romanian Post carriers (home delivery and pickup points).
+
 = 2.3.1 =
 Fixed: Database structure was not updated after updating the plugin.
 

--- a/src/Packetery/Module/Plugin.php
+++ b/src/Packetery/Module/Plugin.php
@@ -19,7 +19,7 @@ use Packetery\Module\Hooks\HookRegistrar;
  */
 class Plugin {
 
-	public const VERSION                = '2.3.1';
+	public const VERSION                = '2.3.2';
 	public const DOMAIN                 = 'packeta';
 	public const PARAM_PACKETERY_ACTION = 'packetery_action';
 	public const PARAM_NONCE            = '_wpnonce';

--- a/src/Packetery/Module/Shipping/Generated/ShippingMethod_39233.php
+++ b/src/Packetery/Module/Shipping/Generated/ShippingMethod_39233.php
@@ -11,9 +11,9 @@ namespace Packetery\Module\Shipping\Generated;
 use Packetery\Module\Shipping\BaseShippingMethod;
 
 /**
- * IE An Post HD
+ * RO Romanian Post HD
  */
-class ShippingMethod_9990 extends BaseShippingMethod
+class ShippingMethod_39233 extends BaseShippingMethod
 {
-	public const CARRIER_ID = '9990';
+	public const CARRIER_ID = '39233';
 }

--- a/src/Packetery/Module/Shipping/Generated/ShippingMethod_39234.php
+++ b/src/Packetery/Module/Shipping/Generated/ShippingMethod_39234.php
@@ -11,9 +11,9 @@ namespace Packetery\Module\Shipping\Generated;
 use Packetery\Module\Shipping\BaseShippingMethod;
 
 /**
- * IE An Post HD
+ * RO Romanian Post PP
  */
-class ShippingMethod_9990 extends BaseShippingMethod
+class ShippingMethod_39234 extends BaseShippingMethod
 {
-	public const CARRIER_ID = '9990';
+	public const CARRIER_ID = '39234';
 }


### PR DESCRIPTION
Ticket: https://packeta.atlassian.net/browse/PES-3336

- Doplňuje dopravce **RO Romanian Post HD (39233)** a **PP (39234)**, verze **2.3.2**.
- Opravuje docblock 9990 na `IE An Post HD` podle klientské sekce (feed má u tohoto ID zastaralý název; generátor existující třídy nepřepisuje).

Changelog: `Added: Romanian Post carriers (home delivery and pickup points).`

Testy: upgrade 2.3.1 → 2.3.2 i čistá instalace OK, objednávka přes oba nové dopravce prošla.

Poznámka: červený job `Run composer security audit` není z této změny — padá i na `PES-3270-v2.3_release-2.3.1` (červenec) kvůli advisories v dev nástrojích (`wpcs`, `symfony/process`). Tento PR composer soubory nemění.
