### PR TITLE
PES-3342: fix destination country detection in hidden shipping form

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 == Changelog ==
 = 2.3.2 =
 Added: Romanian Post carriers (home delivery and pickup points).
+Fixed: The widget used the billing country instead of the shipping country when the shipping address form was hidden in the checkout.
 
 = 2.3.1 =
 Fixed: Database structure was not updated after updating the plugin.

--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -13,13 +13,22 @@ var packeteryLoadCheckout = function( $, settings ) {
 		} );
 	}
 
-	var getCheckoutAddress = function () {
-		var section = '';
-		if ( $( '#ship-to-different-address-checkbox:checked' ).length === 1 ) {
-			section = 'shipping';
+	var getDestinationAddressSection = function () {
+		if ( $( '#ship-to-different-address-checkbox' ).length === 1 ) {
+			if ( $( '#ship-to-different-address-checkbox:checked' ).length === 1 ) {
+				return 'shipping';
+			} else {
+				return 'billing';
+			}
+		} else if ( $( '#shipping_country:visible' ).length === 1 ) {
+			return 'shipping';
 		} else {
-			section = 'billing';
+			return 'billing';
 		}
+	}
+
+	var getDestinationAddressElements = function () {
+		const section = getDestinationAddressSection();
 		return {
 			street: $( '#' + section + '_address_1' ),
 			city: $( '#' + section + '_city' ),
@@ -59,11 +68,7 @@ var packeteryLoadCheckout = function( $, settings ) {
 				};
 			};
 
-			if ( $( '#shipping_country:visible' ).length === 1 ) {
-				return extractDestination( 'shipping' );
-			} else {
-				return extractDestination( 'billing' );
-			}
+			return extractDestination( getDestinationAddressSection() );
 		};
 
 		var getRateAttrValue = function( carrierRateId, attribute, defaultValue ) {
@@ -109,7 +114,7 @@ var packeteryLoadCheckout = function( $, settings ) {
 		};
 
 		var rewriteDestinationAddress = function ( carrierRateId ) {
-			var destinationAddress = getCheckoutAddress();
+			var destinationAddress = getDestinationAddressElements();
 			destinationAddress.street.val( getRateAttrValue( carrierRateId, 'packetery_address_street', '' ) + ' ' + getRateAttrValue( carrierRateId, 'packetery_address_houseNumber', '' ) );
 			destinationAddress.city.val( getRateAttrValue( carrierRateId, 'packetery_address_city', '' ) );
 			destinationAddress.postCode.val( getRateAttrValue( carrierRateId, 'packetery_address_postCode', '' ) );
@@ -442,8 +447,10 @@ var packeteryLoadCheckout = function( $, settings ) {
 		$( document ).on( 'click', '.packeta-widget-button', function( e ) {
 			e.preventDefault();
 
+			var destinationAddress = getDestinationAddress();
+			var country = destinationAddress.country || settings.country;
 			var widgetOptions = {
-				country: settings.country,
+				country: country,
 				language: settings.language
 			};
 
@@ -451,8 +458,6 @@ var packeteryLoadCheckout = function( $, settings ) {
 			if ( hasHomeDelivery( carrierRateId ) ) {
 				widgetOptions.layout = 'hd';
 				widgetOptions.appIdentity = settings.appIdentity;
-
-				var destinationAddress = getDestinationAddress();
 				widgetOptions.street = destinationAddress.street;
 				widgetOptions.city = destinationAddress.city;
 				widgetOptions.postcode = destinationAddress.postCode;

--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,7 @@ Please contact us at e-commerce.support@packeta.com .
 == Changelog ==
 = 2.3.2 =
 Added: Romanian Post carriers (home delivery and pickup points).
+Fixed: The widget used the billing country instead of the shipping country when the shipping address form was hidden in the checkout.
 
 = 2.3.1 =
 Fixed: Database structure was not updated after updating the plugin.


### PR DESCRIPTION
- Widget bral v pokladně **fakturační** zemi místo doručovací, když je formulář doručovací adresy skrytý CSS (kroková pokladna) a volba „Ship to different address" je přitom zaškrtnutá. Zákazník s doručením na SK tak dostal nabídku českých poboček.
- Oprava je **cherry-pick `2fa92de3` z `pre-release`** (PR #919, PES-3085). Tam se mergla 11. 2. 2026, ale do release větve `v2.3` se nikdy nepropsala, takže v žádné vydané verzi není. Merge tímhle směrem nešel — `pre-release` je napřed o ~94 nesouvisejících commitů.
- Aplikovalo se **bez konfliktu**; změněné řádky jsou identické s originálem, posunulo se jen číslování (`v2.3` má navíc PES-2967).
- Vydá se ve **2.3.2** — bump verze už proběhl v PES-3336, tento PR ho nepřidává.

Changelog: `Fixed: The widget used the billing country instead of the shipping country when the shipping address form was hidden in the checkout.`

Testy: **na této větvi netestováno.** Kód je obsahově identický s tím, co v rámci PES-3085 otestoval Matyáš Kovaľ 26. 2. 2026 na `pre-release`. Změna je v JS, PHPUnit ji nepokrývá.

Dopad na pozdější merge `v2.3` → `pre-release`: `checkout.js` bude mít stejný obsah pod dvěma SHA a changelog záznam bude duplicitní (tady pod `= 2.3.2 =`, tam u přečíslované mainline verze) — sladit ručně.
